### PR TITLE
chore: update claudecodeui chart and image to 1.30

### DIFF
--- a/ai-services/claudecodeui/kustomization.yaml
+++ b/ai-services/claudecodeui/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: claudecodeui
 helmCharts:
   - name: claudecodeui
     repo: "oci://ghcr.io/ryanbeales/charts"
-    version: 1.30.0
+    version: 1.3.0
     releaseName: claudecodeui
     namespace: claudecodeui
     valuesFile: values.yaml

--- a/ai-services/claudecodeui/kustomization.yaml
+++ b/ai-services/claudecodeui/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: claudecodeui
 helmCharts:
   - name: claudecodeui
     repo: "oci://ghcr.io/ryanbeales/charts"
-    version: 1.2.1
+    version: 1.30.0
     releaseName: claudecodeui
     namespace: claudecodeui
     valuesFile: values.yaml

--- a/ai-services/claudecodeui/values.yaml
+++ b/ai-services/claudecodeui/values.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: "1.30"
-
 ingress:
   enabled: false
 

--- a/ai-services/claudecodeui/values.yaml
+++ b/ai-services/claudecodeui/values.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: "1.30"
+
 ingress:
   enabled: false
 


### PR DESCRIPTION
Updates claudecodeui Helm chart to 1.30.0 and image tag to 1.30.