### PR TITLE
fix/hermes tui crash

### DIFF
--- a/ai-services/hermes/deployment.yaml
+++ b/ai-services/hermes/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: hermes
           image: nousresearch/hermes-agent:latest
+          args: ["gateway", "run"]
           env:
             - name: HERMES_DASHBOARD
               value: "1"


### PR DESCRIPTION
- feat: Add Hermes Agent deployment to ai-services
- fix: Disable Hermes TUI to prevent pod crash
- fix: Start hermes as a gateway server
