### PR TITLE
fix/hermes tui crash

### DIFF
--- a/ai-services/hermes/deployment.yaml
+++ b/ai-services/hermes/deployment.yaml
@@ -20,8 +20,12 @@ spec:
         - name: hermes
           image: nousresearch/hermes-agent:latest
           args: ["gateway", "run"]
+          tty: true
+          stdin: true
           env:
             - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
               value: "1"
 
             - name: API_SERVER_ENABLED


### PR DESCRIPTION
- feat: Add Hermes Agent deployment to ai-services
- fix: Disable Hermes TUI to prevent pod crash
- fix: Start hermes as a gateway server
- feat: Enable Web TUI with pseudo-TTY
