### PR TITLE
fix/maddy config 2

### DIFF
--- a/cluster-services/maddy/configmap.yaml
+++ b/cluster-services/maddy/configmap.yaml
@@ -13,6 +13,8 @@ data:
     $(hostname) = maddy.maddy.svc.cluster.local
     $(domain) = ryanbeales.com
 
+    hostname $(hostname)
+
     auth.pass_table local_authdb {
         table sql_table {
             driver sqlite3

--- a/cluster-services/maddy/deployment.yaml
+++ b/cluster-services/maddy/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - |
               export SES_SMTP_USER=$(cat /data/secrets/smtp_user)
               export SES_SMTP_PASSWORD=$(cat /data/secrets/smtp_pass)
-              exec maddy -config /etc/maddy/maddy.conf
+              exec maddy -config /etc/maddy/maddy.conf run
           ports:
             - containerPort: 25
               name: smtp


### PR DESCRIPTION
- fix: syntax for maddy config macros
- fix: maddy hostname global directive and run command syntax
