### PR TITLE
fix/maddy config 6

### DIFF
--- a/cluster-services/maddy/configmap.yaml
+++ b/cluster-services/maddy/configmap.yaml
@@ -71,8 +71,6 @@ data:
     }
 
     target.smtp ses_relay tcp://email-smtp.us-west-2.amazonaws.com:587 {
-        tls_client {
-        }
         auth plain {env:SES_SMTP_USER} {env:SES_SMTP_PASSWORD}
     }
 


### PR DESCRIPTION
- fix: remove invalid source_ip directive from maddy conf
- fix: target.smtp syntax
- fix: remove tls_client block to prevent reflect type panic in maddy
