### PR TITLE
chore: isolate crobputer and relocate workloads

### DIFF
--- a/ai-services/ollama-large/deployment.yaml
+++ b/ai-services/ollama-large/deployment.yaml
@@ -17,6 +17,11 @@ spec:
     spec:
       runtimeClassName: nvidia
       nodeName: crobputer
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: crobputer
+          effect: NoSchedule
       containers:
         - name: ollama
           # renovate: datasource=github-tags depname=ollama/ollama versioning=semver

--- a/ai-services/open-webui/deployment.yaml
+++ b/ai-services/open-webui/deployment.yaml
@@ -16,6 +16,16 @@ spec:
       labels:
         app.kubernetes.io/name: open-webui
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - croblodocus
+                      - crobceratops
       containers:
         - name: open-webui
           # renovate: datasource=github-tags depname=open-webui/open-webui versioning=semver

--- a/cluster-services/node-feature-discovery/kustomization.yaml
+++ b/cluster-services/node-feature-discovery/kustomization.yaml
@@ -1,2 +1,13 @@
 resources:
 - https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.18.3
+
+patches:
+  - target:
+      kind: DaemonSet
+      name: nfd-worker
+    patch: |
+      spec:
+        template:
+          spec:
+            tolerations:
+              - operator: Exists

--- a/cluster-services/node-feature-discovery/kustomization.yaml
+++ b/cluster-services/node-feature-discovery/kustomization.yaml
@@ -6,6 +6,10 @@ patches:
       kind: DaemonSet
       name: nfd-worker
     patch: |
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: nfd-worker
       spec:
         template:
           spec:

--- a/cluster-services/node-tuning/daemonset.yaml
+++ b/cluster-services/node-tuning/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app.kubernetes.io/name: node-tuning
     spec:
+      tolerations:
+        - operator: Exists
       hostNetwork: true
       hostPID: true
       initContainers:

--- a/cluster-services/nvidia-gpu/daemonset.yaml
+++ b/cluster-services/nvidia-gpu/daemonset.yaml
@@ -18,6 +18,10 @@ spec:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: crobputer
+        effect: NoSchedule
       # Mark this pod as a critical add-on; when enabled, the critical add-on
       # scheduler reserves resources for critical add-on pods so that they can
       # be rescheduled after a failure.

--- a/home-automation/faster-whisper/deployment.yaml
+++ b/home-automation/faster-whisper/deployment.yaml
@@ -19,9 +19,10 @@ spec:
       # Switch to the nvidia runtime class to get access to GPUs
       runtimeClassName: nvidia
 
-      # This process is tiny, we have a 1050Ti-4GB, 1060-6GB, and 3060-12GB in the cluster. We won't restrict this to a specific node.
+      # Pins faster-whisper to crobceratops to relieve memory pressure on crobasaurusrex
       nodeSelector:
         nvidia.com/gpu.present: "true"
+        kubernetes.io/hostname: crobceratops
 
       containers:
         - name: faster-whisper

--- a/home-automation/piper/deployment.yaml
+++ b/home-automation/piper/deployment.yaml
@@ -19,9 +19,10 @@ spec:
       # Switch to the nvidia runtime class to get access to the GPU
       runtimeClassName: nvidia
       
-      # This process is tiny, we have a 1050Ti-4GB, 1060-6GB, and 3060-12GB in the cluster. We won't restrict this to a specific node.
+      # Pins piper to crobceratops to relieve memory pressure on crobasaurusrex
       nodeSelector:
         nvidia.com/gpu.present: "true"
+        kubernetes.io/hostname: crobceratops
 
       containers:
       - name: piper

--- a/monitoring/kube-prometheus-stack/values.yaml
+++ b/monitoring/kube-prometheus-stack/values.yaml
@@ -181,6 +181,9 @@ kubeScheduler:
 kubeControllerManager:
   enabled: false
 
+kubeProxy:
+  enabled: false
+
 kubeStateMetrics:
   namespaceOverride: kube-prometheus-stack
 

--- a/monitoring/loki-stack/loki-values.yaml
+++ b/monitoring/loki-stack/loki-values.yaml
@@ -1,5 +1,8 @@
 deploymentMode: SingleBinary
 
+lokiCanary:
+  enabled: false
+
 loki:
   auth_enabled: false
 

--- a/monitoring/loki-stack/promtail-values.yaml
+++ b/monitoring/loki-stack/promtail-values.yaml
@@ -1,3 +1,15 @@
 config:
   clients:
     - url: http://loki.loki-stack.svc:3100/loki/api/v1/push
+
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  - key: dedicated
+    operator: Equal
+    value: crobputer
+    effect: NoSchedule


### PR DESCRIPTION
Relocates CPU and GPU workloads off crobasaurusrex, configures a NoSchedule taint for crobputer, adds tolerations to all DaemonSets and ollama-large, and disables loki-canary and KubeProxy target monitoring.