### PR TITLE
chore(gitea): fix actions runner rendering for helm actions 0.1.1 and runner 1.0.5

### DIFF
--- a/development-services/gitea/kustomization.yaml
+++ b/development-services/gitea/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
     includeCRDs: true
   - name: actions
     repo: "oci://docker.gitea.com/charts/"
-    version: 0.1.0 # https://gitea.com/gitea/helm-chart/releases
+    version: 0.1.1 # https://gitea.com/gitea/helm-chart/releases
     releaseName: actions
     namespace: gitea
     valuesFile: values-actions.yaml
@@ -28,7 +28,7 @@ patches:
   # these fields to be present in the live cluster state.
   - target:
       kind: StatefulSet
-      name: actions-act-runner
+      name: actions-runner
     patch: |-
       - op: add
         path: /spec/volumeClaimTemplates/0/apiVersion

--- a/development-services/gitea/values-actions.yaml
+++ b/development-services/gitea/values-actions.yaml
@@ -13,10 +13,10 @@ statefulset:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
-  actRunner:
-    # https://hub.docker.com/r/gitea/act_runner/tags
-    # renovate: datasource=gitea-releases depname=gitea/act_runner versioning=docker
-    tag: 0.4.1
+  runner:
+    # https://gitea.com/gitea/runner/releases
+    # renovate: datasource=gitea-releases depname=gitea/runner versioning=docker
+    tag: 1.0.5
     # By default, the helm chart does not populate the labels section of the runner config.
     # This means all jobs start in a bare image without the necessary tools.
     config: |
@@ -49,7 +49,7 @@ preExtraInitContainers:
       - -c
       - chown -R 1000:1000 /data
     volumeMounts:
-      - name: data-act-runner
+      - name: data-runner
         mountPath: /data
 
 global:

--- a/development-services/gitea/values.yaml
+++ b/development-services/gitea/values.yaml
@@ -61,3 +61,5 @@ gitea:
     indexer:
       ISSUE_INDEXER_TYPE: bleve
       REPO_INDEXER_ENABLED: true
+    server:
+      HTTP_PORT: 3000


### PR DESCRIPTION
This PR fixes the rendering and volume mapping failures for Gitea Actions runners introduced in the upgraded Helm Chart version 0.1.1 and runner version 1.0.5, and also bumps Gitea Helm Chart to version 12.6.0. It supersedes PRs #837, #765, #749, and #799.

### Changes:
- **kustomization.yaml**: Upgrade actions helm chart to 0.1.1, upgrade gitea helm chart to 12.6.0, and target \ctions-runner\ (instead of \ctions-act-runner\) for the volumeClaimTemplates patches.
- **values-actions.yaml**: Rename \ctRunner\ key to \unner\, set tag to \1.0.5\, and rename volume mount name to \data-runner\ in the permissions init container.
- **values.yaml**: Add \gitea.config.server.HTTP_PORT: 3000\ to resolve the schema validation issue with \	argetPort: null\ in the \gitea-http\ Service.