### PR TITLE
chore: disable unused rules and route NodeMemoryHighUtilization/InfoInhibitor to null

### DIFF
--- a/monitoring/kube-prometheus-stack/values.yaml
+++ b/monitoring/kube-prometheus-stack/values.yaml
@@ -1,5 +1,13 @@
 namespaceOverride: kube-prometheus-stack
 
+defaultRules:
+  create: true
+  rules:
+    etcd: false
+    kubeScheduler: false
+    kubeControllerManager: false
+    kubeProxy: false
+
 alertmanager:
   config:
     global:
@@ -22,7 +30,9 @@ alertmanager:
         receiver: 'null'
       - match:
           alertname: NodeMemoryHighUtilization
-          instance: '10.0.0.59:9100'
+        receiver: 'null'
+      - match:
+          alertname: InfoInhibitor
         receiver: 'null'
     receivers:
     - name: 'null'


### PR DESCRIPTION
Disables unused rule groups (etcd, scheduler, controller manager, kube-proxy) and updates Alertmanager routes to silence NodeMemoryHighUtilization on all nodes and the InfoInhibitor helper alert.