### PR TITLE
feat: add automatic NVIDIA driver mismatch rebooter daemonset

### DIFF
--- a/cluster-services/nvidia-mismatch-rebooter/argocd.yaml
+++ b/cluster-services/nvidia-mismatch-rebooter/argocd.yaml
@@ -1,0 +1,3 @@
+argocd:
+  name: nvidia-mismatch-rebooter
+  namespace: kube-system

--- a/cluster-services/nvidia-mismatch-rebooter/check-mismatch.sh
+++ b/cluster-services/nvidia-mismatch-rebooter/check-mismatch.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+# Configuration
+CHECK_INTERVAL_SECONDS=${CHECK_INTERVAL_SECONDS:-1800} # default: 30 minutes
+REBOOT_WINDOW_HOUR=${REBOOT_WINDOW_HOUR:-4}             # default: 4 AM
+
+echo "Starting NVIDIA driver/library mismatch reboot daemon..."
+echo "Configured to check at hour: $REBOOT_WINDOW_HOUR (local time), checking every $CHECK_INTERVAL_SECONDS seconds."
+
+while true; do
+  CURRENT_HOUR=$(date +%H)
+  # Strip leading zero to avoid octal interpretation issues in shell arithmetic
+  CURRENT_HOUR=${CURRENT_HOUR#0}
+  CURRENT_HOUR=${CURRENT_HOUR:-0}
+  
+  if [ "$CURRENT_HOUR" -eq "$REBOOT_WINDOW_HOUR" ]; then
+    echo "Current hour is $CURRENT_HOUR, running nvidia-smi check on the host..."
+    
+    # Run nvidia-smi in the host's namespaces.
+    # We redirect stderr to check if it contains the version mismatch string.
+    if ! ERROR_MSG=$(nsenter -t 1 -m -u -i -n -p -- nvidia-smi 2>&1); then
+      echo "nvidia-smi check failed: $ERROR_MSG"
+      if echo "$ERROR_MSG" | grep -qi "version mismatch"; then
+        echo "CRITICAL: NVIDIA Driver/Library Version Mismatch detected on host!"
+        echo "Rebooting host node in 10 seconds..."
+        sleep 10
+        nsenter -t 1 -m -u -i -n -p -- reboot
+        # Sleep for a long time to prevent reboot loop if reboot takes time
+        sleep 3600
+      else
+        echo "nvidia-smi failed, but not due to a version mismatch. Skipping reboot."
+      fi
+    else
+      echo "NVIDIA driver is healthy. nvidia-smi succeeded."
+    fi
+  else
+    echo "Current hour is $CURRENT_HOUR. Reboot window is $REBOOT_WINDOW_HOUR:00. Skipping check."
+  fi
+  
+  sleep "$CHECK_INTERVAL_SECONDS"
+done

--- a/cluster-services/nvidia-mismatch-rebooter/daemonset.yaml
+++ b/cluster-services/nvidia-mismatch-rebooter/daemonset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-mismatch-rebooter
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-mismatch-rebooter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-mismatch-rebooter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-mismatch-rebooter
+    spec:
+      tolerations:
+        - operator: Exists
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      hostPID: true
+      containers:
+        - name: rebooter
+          image: alpine:3.18
+          command:
+            - /bin/sh
+            - -c
+            - "/scripts/check-mismatch.sh"
+          securityContext:
+            privileged: true
+          env:
+            - name: CHECK_INTERVAL_SECONDS
+              value: "1800"
+            - name: REBOOT_WINDOW_HOUR
+              value: "4"
+          volumeMounts:
+            - name: script-volume
+              mountPath: /scripts
+            - name: tz-config
+              mountPath: /etc/localtime
+              readOnly: true
+            - name: timezone-config
+              mountPath: /etc/timezone
+              readOnly: true
+          resources:
+            limits:
+              cpu: 10m
+              memory: 20Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
+      volumes:
+        - name: script-volume
+          configMap:
+            name: nvidia-mismatch-rebooter-script
+            defaultMode: 0755
+        - name: tz-config
+          hostPath:
+            path: /etc/localtime
+        - name: timezone-config
+          hostPath:
+            path: /etc/timezone

--- a/cluster-services/nvidia-mismatch-rebooter/kustomization.yaml
+++ b/cluster-services/nvidia-mismatch-rebooter/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./daemonset.yaml
+configMapGenerator:
+  - name: nvidia-mismatch-rebooter-script
+    files:
+      - check-mismatch.sh
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
Implements a node-local daemonset to monitor GPU nodes for NVIDIA Driver/Library version mismatches and automatically reboot the host during the designated overnight window (4:00 AM local time).