### PR TITLE
chore: silence NodeMemoryMajorPagesFaults alert for crobasaurusrex

### DIFF
--- a/monitoring/kube-prometheus-stack/values.yaml
+++ b/monitoring/kube-prometheus-stack/values.yaml
@@ -34,6 +34,10 @@ alertmanager:
       - match:
           alertname: InfoInhibitor
         receiver: 'null'
+      - match_re:
+          alertname: NodeMemoryMajorPagesFaults
+          instance: ^10\.0\.0\.59:.*$
+        receiver: 'null'
     receivers:
     - name: 'null'
     - name: 'email-notifications'


### PR DESCRIPTION
Silences the NodeMemoryMajorPagesFaults alert specifically on node crobasaurusrex (IP 10.0.0.59) by routing it to the null receiver.