### PR TITLE
feat(nfd): add usb-devices rules and update zwave/octoprint node selectors

### DIFF
--- a/cluster-services/node-feature-discovery/kustomization.yaml
+++ b/cluster-services/node-feature-discovery/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.18.3
+- usb-devices-rules.yaml
 
 patches:
   - target:

--- a/cluster-services/node-feature-discovery/usb-devices-rules.yaml
+++ b/cluster-services/node-feature-discovery/usb-devices-rules.yaml
@@ -1,0 +1,23 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: usb-devices
+  namespace: node-feature-discovery
+spec:
+  rules:
+    - name: "aeotec-zstick"
+      labels:
+        "feature.node.kubernetes.io/usb-aeotec-zstick": "true"
+      matchFeatures:
+        - feature: usb.device
+          matchExpressions:
+            vendor: {op: In, value: ["0658"]}
+            device: {op: In, value: ["0200"]}
+    - name: "biqu-b1"
+      labels:
+        "feature.node.kubernetes.io/usb-biqu-b1": "true"
+      matchFeatures:
+        - feature: usb.device
+          matchExpressions:
+            vendor: {op: In, value: ["1d50"]}
+            device: {op: In, value: ["6029"]}

--- a/cluster-services/nvidia-gpu/gpu-feature-discovery.yaml
+++ b/cluster-services/nvidia-gpu/gpu-feature-discovery.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-gpu-feature-discovery
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: gpu-feature-discovery
+    app.kubernetes.io/version: 0.17.4
+    app.kubernetes.io/part-of: nvidia-gpu
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-gpu-feature-discovery
+  template:
+    metadata:
+      labels:
+        name: nvidia-gpu-feature-discovery
+        app.kubernetes.io/name: gpu-feature-discovery
+        app.kubernetes.io/version: 0.17.4
+        app.kubernetes.io/part-of: nvidia-gpu
+    spec:
+      runtimeClassName: nvidia
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: dedicated
+          operator: Equal
+          value: crobputer
+          effect: NoSchedule
+      containers:
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.4
+          name: gpu-feature-discovery
+          command: ["/usr/bin/gpu-feature-discovery"]
+          env:
+            - name: GFD_SLEEP_INTERVAL
+              value: "60s"
+            - name: GFD_FAIL_ON_INIT_ERROR
+              value: "false"
+            - name: GFD_OUTPUT_DIR
+              value: "/etc/kubernetes/node-feature-discovery/features.d"
+          volumeMounts:
+            - name: output-dir
+              mountPath: /etc/kubernetes/node-feature-discovery/features.d
+            - name: host-sys
+              mountPath: /sys
+              readOnly: true
+      volumes:
+        - name: output-dir
+          hostPath:
+            path: /etc/kubernetes/node-feature-discovery/features.d
+        - name: host-sys
+          hostPath:
+            path: /sys

--- a/cluster-services/nvidia-gpu/kustomization.yaml
+++ b/cluster-services/nvidia-gpu/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - ./nvidia-runtime.yaml
 - ./daemonset.yaml
+- ./gpu-feature-discovery.yaml
 - ./time-slicing-config.yaml

--- a/home-automation/zwavejs/deployment.yaml
+++ b/home-automation/zwavejs/deployment.yaml
@@ -82,7 +82,7 @@ spec:
               name: usb
       enableServiceLinks: true
       nodeSelector:
-        kubernetes.io/hostname: crobasaurusrex
+        feature.node.kubernetes.io/usb-aeotec-zstick: "true"
       restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 30

--- a/self-hosted-services/octoprint/deployment.yaml
+++ b/self-hosted-services/octoprint/deployment.yaml
@@ -21,8 +21,8 @@ spec:
         app.kubernetes.io/part-of: octoprint
     spec:
       nodeSelector:
-        # Biqu B1 is on crobceratops - this isn't appearing in node-feature-discovery to be portable
-        kubernetes.io/hostname: crobceratops
+        # Biqu B1 is on crobceratops
+        feature.node.kubernetes.io/usb-biqu-b1: "true"
       containers:
       - name: octoprint
         # https://hub.docker.com/r/octoprint/octoprint/tags


### PR DESCRIPTION
This PR introduces custom NFD rules to detect Z-Stick Gen5 and Marlin 3D printer USB devices and schedules the zwavejs and octoprint deployments based on those NFD labels.