### PR TITLE
fix(zfs-snapshot-cleanup): remove invalid hostpath mount of /proc/self/mounts

### DIFF
--- a/cluster-services/crobasaurusrex-admin/zfs-snapshot-cleanup-cronjob.yaml
+++ b/cluster-services/crobasaurusrex-admin/zfs-snapshot-cleanup-cronjob.yaml
@@ -26,8 +26,6 @@ spec:
               readOnly: true
             - name: zfs-dev
               mountPath: /dev/zfs
-            - name: zfs-mounts
-              mountPath: /proc/self/mounts
           volumes:
           - name: zfs-snapshot-cleanup-script
             configMap:
@@ -35,7 +33,4 @@ spec:
           - name: zfs-dev
             hostPath:
               path: /dev/zfs
-          - name: zfs-mounts
-            hostPath:
-              path: /proc/self/mounts
           restartPolicy: Never


### PR DESCRIPTION
This PR removes the HostPath volume mount of `/proc/self/mounts` inside the `zfs-snapshot-cleanup` CronJob, resolving the `StartError` in modern containerd/runc runtimes.