### PR TITLE
fix(hermes): use basic auth secret for dashboard

### DIFF
--- a/ai-services/hermes/README.md
+++ b/ai-services/hermes/README.md
@@ -37,12 +37,12 @@ kubectl create secret generic hermes-gemini-secret -n hermes --from-literal=GEMI
 *(The `deployment.yaml` references this secret and exposes it to the agent as the `GEMINI_API_KEY` environment variable).*
 
 ### 3. Create Kubernetes Secret (Dashboard Auth)
-To secure the Hermes Dashboard, you must provide a basic auth username and password:
+To secure the Hermes Dashboard, you must provide a basic auth username and password. We recommend generating a strong password using `openssl`:
 
 ```bash
 kubectl create secret generic hermes-dashboard-secret -n hermes \
   --from-literal=username=admin \
-  --from-literal=password='YOUR_PASSWORD'
+  --from-literal=password=$(openssl rand -base64 16)
 ```
 *(The `deployment.yaml` references this secret and exposes it to the agent).*
 

--- a/ai-services/hermes/README.md
+++ b/ai-services/hermes/README.md
@@ -24,15 +24,29 @@ Before deploying the Hermes agent via ArgoCD, you **must** configure a GitHub Pe
 4. Generate the token and copy it.
 5. Create the Kubernetes secret:
 ```bash
-kubectl create secret generic hermes-github-secret -n hermes --from-literal=GITHUB_TOKEN=ghp_YO...(The `deployment.yaml` references this secret and exposes it to the agent as the `GITHUB_TOKEN` environment variable).*
+kubectl create secret generic hermes-github-secret -n hermes --from-literal=GITHUB_TOKEN=ghp_YO...
+```
+*(The `deployment.yaml` references this secret and exposes it to the agent as the `GITHUB_TOKEN` environment variable).*
 
 ### 2. Create Kubernetes Secret (Gemini)
 To enable the Gemini integrations/models, deploy your Gemini API key as a secret in the `hermes` namespace:
 
 ```bash
-kubectl create secret generic hermes-gemini-secret -n hermes --from-literal=GEMINI_API_KEY=AIzaSy...(The `deployment.yaml` references this secret and exposes it to the agent as the `GEMINI_API_KEY` environment variable).*
+kubectl create secret generic hermes-gemini-secret -n hermes --from-literal=GEMINI_API_KEY=AIzaSy...
+```
+*(The `deployment.yaml` references this secret and exposes it to the agent as the `GEMINI_API_KEY` environment variable).*
 
-### 3. Adding SearXNG MCP Support
+### 3. Create Kubernetes Secret (Dashboard Auth)
+To secure the Hermes Dashboard, you must provide a basic auth username and password:
+
+```bash
+kubectl create secret generic hermes-dashboard-secret -n hermes \
+  --from-literal=username=admin \
+  --from-literal=password='YOUR_PASSWORD'
+```
+*(The `deployment.yaml` references this secret and exposes it to the agent).*
+
+### 4. Adding SearXNG MCP Support
 If you want to enable SearXNG search capabilities, add the MCP server to your Hermes configuration. 
 
 Run the following command from a terminal with `hermes` access (e.g., within the cluster):

--- a/ai-services/hermes/deployment.yaml
+++ b/ai-services/hermes/deployment.yaml
@@ -92,8 +92,16 @@ spec:
               value: "1"
             - name: HERMES_DASHBOARD_TUI
               value: "1"
-            - name: HERMES_DASHBOARD_INSECURE
-              value: "1"
+            - name: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-dashboard-secret
+                  key: username
+            - name: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-dashboard-secret
+                  key: password
 
             - name: API_SERVER_ENABLED
               value: "true"


### PR DESCRIPTION
Fixes hermes dashboard binding error by enabling basic auth through a k8s secret. Updates README with instructions on how to generate the secret with a strong openssl-generated password.