### PR TITLE
Update immich-album-export image tag to sha-ed10587

### DIFF
--- a/self-hosted-services/image-album-export/cronjob-melissa.yaml
+++ b/self-hosted-services/image-album-export/cronjob-melissa.yaml
@@ -19,7 +19,7 @@ spec:
             kubernetes.io/hostname: crobasaurusrex
           containers:
           - name: immich-album-export
-            image: ghcr.io/ryanbeales/immich-album-export:latest
+            image: ghcr.io/ryanbeales/immich-album-export:sha-ed10587
             imagePullPolicy: Always
             env:
             # K8s local URL for immich service

--- a/self-hosted-services/image-album-export/cronjob-ryan.yaml
+++ b/self-hosted-services/image-album-export/cronjob-ryan.yaml
@@ -19,7 +19,7 @@ spec:
             kubernetes.io/hostname: crobasaurusrex
           containers:
           - name: immich-album-export
-            image: ghcr.io/ryanbeales/immich-album-export:latest
+            image: ghcr.io/ryanbeales/immich-album-export:sha-ed10587
             imagePullPolicy: Always
             env:
             # K8s local URL for immich service


### PR DESCRIPTION
Updates the image tags for Ryan and Melissa's cronjobs to use the new immich v3 compatible script.