### PR TITLE
fix frigate detector

### DIFF
--- a/self-hosted-services/frigate/frigate-config.yaml
+++ b/self-hosted-services/frigate/frigate-config.yaml
@@ -90,7 +90,7 @@ detect:
 detectors:
   onnx:
     type: onnx
-    device: cuda
+    device: tensorrt
 model:
   model_type: yolo-generic
   width: 320


### PR DESCRIPTION
- **Update LiteLLM routing strategy with strict aliases and concurrency limits**
- **fix: change frigate ONNX detector device to tensorrt**
