### PR TITLE
fix(litellm): add trailing slash to prometheus metrics endpoint path

### DIFF
--- a/ai-services/litellm/servicemonitor.yaml
+++ b/ai-services/litellm/servicemonitor.yaml
@@ -9,7 +9,7 @@ spec:
       app.kubernetes.io/name: litellm
   endpoints:
     - port: http
-      path: /metrics
+      path: /metrics/
   namespaceSelector:
     matchNames:
       - litellm


### PR DESCRIPTION
LiteLLM metrics endpoint redirects to /metrics/ with a trailing slash, breaking prometheus scrapes. This adds the trailing slash directly.