### PR TITLE
fix(litellm): add matching labels to service metadata for servicemonitor

### DIFF
--- a/ai-services/litellm/service.yaml
+++ b/ai-services/litellm/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: litellm
   namespace: litellm
+  labels:
+    app.kubernetes.io/name: litellm
 spec:
   selector:
     app.kubernetes.io/name: litellm


### PR DESCRIPTION
The ServiceMonitor was looking for a Service with the app.kubernetes.io/name: litellm label, but the Service metadata didn't have any labels. This adds the label so prometheus-operator can discover it.