### PR TITLE
fix: conditionally copy klipper configs and prevent CRLF line ending issues

### DIFF
--- a/self-hosted-services/klipper/klipper-deployment.yaml
+++ b/self-hosted-services/klipper/klipper-deployment.yaml
@@ -41,16 +41,18 @@ spec:
             - /bin/sh
             - -c
             - |
-              set -e -x
-              mkdir -p /opt/printer_data/config /opt/printer_data/logs /opt/printer_data/gcodes /opt/printer_data/run /opt/printer_data/comms
-              chown -R 1000:1000 /opt/printer_data || true
-              chmod -R 777 /opt/printer_data || true
-              ls -la /tmp/config
-              cat /tmp/config/klipper.cfg > /opt/printer_data/config/printer.cfg
-              cat /tmp/config/moonraker.conf > /opt/printer_data/config/moonraker.conf
-              chown -R 1000:1000 /opt/printer_data || true
-              chmod -R 777 /opt/printer_data || true
-              ls -la /opt/printer_data/config
+              set -e -x #
+              mkdir -p /opt/printer_data/config /opt/printer_data/logs /opt/printer_data/gcodes /opt/printer_data/run /opt/printer_data/comms #
+              chown -R 1000:1000 /opt/printer_data || true #
+              chmod -R 777 /opt/printer_data || true #
+              if [ ! -f /opt/printer_data/config/printer.cfg ]; then #
+                cp -L /tmp/config/klipper.cfg /opt/printer_data/config/printer.cfg #
+              fi #
+              if [ ! -f /opt/printer_data/config/moonraker.conf ]; then #
+                cp -L /tmp/config/moonraker.conf /opt/printer_data/config/moonraker.conf #
+              fi #
+              chown -R 1000:1000 /opt/printer_data || true #
+              chmod -R 777 /opt/printer_data || true #
           volumeMounts:
             - mountPath: /opt/printer_data
               name: klipper-pvc


### PR DESCRIPTION
Only copy ConfigMap files if they don't already exist on the PVC. Appends '#' to init-dirs bash commands to prevent trailing CRLF from corrupting filenames or syntax when applied from Windows.