### PR TITLE
fix: revert to cat for config map files

### DIFF
--- a/self-hosted-services/klipper/klipper-deployment.yaml
+++ b/self-hosted-services/klipper/klipper-deployment.yaml
@@ -46,10 +46,10 @@ spec:
               chown -R 1000:1000 /opt/printer_data || true #
               chmod -R 777 /opt/printer_data || true #
               if [ ! -f /opt/printer_data/config/printer.cfg ]; then #
-                cp -L /tmp/config/klipper.cfg /opt/printer_data/config/printer.cfg #
+                cat /tmp/config/klipper.cfg > /opt/printer_data/config/printer.cfg #
               fi #
               if [ ! -f /opt/printer_data/config/moonraker.conf ]; then #
-                cp -L /tmp/config/moonraker.conf /opt/printer_data/config/moonraker.conf #
+                cat /tmp/config/moonraker.conf > /opt/printer_data/config/moonraker.conf #
               fi #
               chown -R 1000:1000 /opt/printer_data || true #
               chmod -R 777 /opt/printer_data || true #


### PR DESCRIPTION
Busybox cp -L appears to fail silently when copying from Kubernetes ConfigMap mounts. Reverting to cat, while keeping the # comment trick and the conditional logic.