### PR TITLE
fix: convert init-dirs script to single line string

### DIFF
--- a/self-hosted-services/klipper/klipper-deployment.yaml
+++ b/self-hosted-services/klipper/klipper-deployment.yaml
@@ -40,19 +40,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - |
-              set -e -x #
-              mkdir -p /opt/printer_data/config /opt/printer_data/logs /opt/printer_data/gcodes /opt/printer_data/run /opt/printer_data/comms #
-              chown -R 1000:1000 /opt/printer_data || true #
-              chmod -R 777 /opt/printer_data || true #
-              if [ ! -f /opt/printer_data/config/printer.cfg ]; then #
-                cat /tmp/config/klipper.cfg > /opt/printer_data/config/printer.cfg #
-              fi #
-              if [ ! -f /opt/printer_data/config/moonraker.conf ]; then #
-                cat /tmp/config/moonraker.conf > /opt/printer_data/config/moonraker.conf #
-              fi #
-              chown -R 1000:1000 /opt/printer_data || true #
-              chmod -R 777 /opt/printer_data || true #
+            - "set -e -x; mkdir -p /opt/printer_data/config /opt/printer_data/logs /opt/printer_data/gcodes /opt/printer_data/run /opt/printer_data/comms; chown -R 1000:1000 /opt/printer_data || true; chmod -R 777 /opt/printer_data || true; if [ ! -f /opt/printer_data/config/printer.cfg ]; then cat /tmp/config/klipper.cfg > /opt/printer_data/config/printer.cfg; fi; if [ ! -f /opt/printer_data/config/moonraker.conf ]; then cat /tmp/config/moonraker.conf > /opt/printer_data/config/moonraker.conf; fi; chown -R 1000:1000 /opt/printer_data || true; chmod -R 777 /opt/printer_data || true"
           volumeMounts:
             - mountPath: /opt/printer_data
               name: klipper-pvc


### PR DESCRIPTION
Converts the multiline YAML script into a single-line string to avoid any issues with carriage returns, newlines, or comment parsing in busybox sh.