### PR TITLE
fix: add diagnostics to init-dirs

### DIFF
--- a/self-hosted-services/klipper/klipper-deployment.yaml
+++ b/self-hosted-services/klipper/klipper-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "set -e -x; mkdir -p /opt/printer_data/config /opt/printer_data/logs /opt/printer_data/gcodes /opt/printer_data/run /opt/printer_data/comms; chown -R 1000:1000 /opt/printer_data || true; chmod -R 777 /opt/printer_data || true; if [ ! -f /opt/printer_data/config/printer.cfg ]; then cat /tmp/config/klipper.cfg > /opt/printer_data/config/printer.cfg; fi; if [ ! -f /opt/printer_data/config/moonraker.conf ]; then cat /tmp/config/moonraker.conf > /opt/printer_data/config/moonraker.conf; fi; chown -R 1000:1000 /opt/printer_data || true; chmod -R 777 /opt/printer_data || true"
+            - "set -e -x; mkdir -p /opt/printer_data/config /opt/printer_data/logs /opt/printer_data/gcodes /opt/printer_data/run /opt/printer_data/comms; ls -la /opt/printer_data/config; if [ ! -f /opt/printer_data/config/printer.cfg ]; then echo 'Copying printer.cfg'; cat /tmp/config/klipper.cfg > /opt/printer_data/config/printer.cfg; else echo 'printer.cfg already exists'; fi; if [ ! -f /opt/printer_data/config/moonraker.conf ]; then echo 'Copying moonraker.conf'; cat /tmp/config/moonraker.conf > /opt/printer_data/config/moonraker.conf; else echo 'moonraker.conf already exists'; fi; chown -R 1000:1000 /opt/printer_data || true; chmod -R 777 /opt/printer_data || true; ls -la /opt/printer_data/config"
           volumeMounts:
             - mountPath: /opt/printer_data
               name: klipper-pvc


### PR DESCRIPTION
Adds explicit echo and ls commands to init-dirs to figure out exactly why the files are not being copied, even when the directory appears empty to the Klipper container.