### PR TITLE
fix: prevent empty volumes from shadowing PVC data

### DIFF
--- a/self-hosted-services/klipper/klipper-deployment.yaml
+++ b/self-hosted-services/klipper/klipper-deployment.yaml
@@ -62,6 +62,18 @@ spec:
           volumeMounts:
             - mountPath: /opt/printer_data
               name: klipper-pvc
+            - mountPath: /opt/printer_data/config
+              name: klipper-pvc
+              subPath: config
+            - mountPath: /opt/printer_data/gcodes
+              name: klipper-pvc
+              subPath: gcodes
+            - mountPath: /opt/printer_data/logs
+              name: klipper-pvc
+              subPath: logs
+            - mountPath: /opt/printer_data/comms
+              name: klipper-pvc
+              subPath: comms
             - mountPath: /opt/printer_data/run
               name: socket-dir
             - mountPath: /dev/ttyACM0
@@ -82,5 +94,17 @@ spec:
           volumeMounts:
             - mountPath: /opt/printer_data
               name: klipper-pvc
+            - mountPath: /opt/printer_data/config
+              name: klipper-pvc
+              subPath: config
+            - mountPath: /opt/printer_data/gcodes
+              name: klipper-pvc
+              subPath: gcodes
+            - mountPath: /opt/printer_data/logs
+              name: klipper-pvc
+              subPath: logs
+            - mountPath: /opt/printer_data/comms
+              name: klipper-pvc
+              subPath: comms
             - mountPath: /opt/printer_data/run
               name: socket-dir


### PR DESCRIPTION
The mkuf/klipper and mkuf/moonraker images have VOLUME declarations for /opt/printer_data/config, gcodes, etc., in their Dockerfiles. In Kubernetes, this causes containerd to mount empty ephemeral volumes OVER those paths, completely hiding the data from the klipper-pvc. This PR adds explicit subPath mounts for those directories to override the ephemeral volumes.