### PR TITLE
fix: correct extruder sensor_pin

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -74,7 +74,7 @@ data:
     filament_diameter: 1.750
     heater_pin: P2.7
     sensor_type: EPCOS 100K B57560G104F
-    sensor_pin: P0.23
+    sensor_pin: P0.24
     min_temp: -100
     max_temp: 275
     control: pid


### PR DESCRIPTION
The extruder thermistor pin was incorrectly set to P0.23 (TH1) instead of the standard P0.24 (TH0) for the SKR 1.4 mainboard, resulting in -99 degree readings. This updates it to the correct pin.