### PR TITLE
fix: allow Klipper to survive MCU reconnects

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -7,7 +7,7 @@ data:
   klipper.cfg: |
     # Klipper Configuration for BIQU B1 with BTT SKR 1.4
     [mcu]
-    serial: /dev/ttyACM0
+    serial: /dev/host/serial/by-id/usb-Klipper_lpc1768_01D00008E5A448AFEBA3375DC42000F5-if00
 
     [printer]
     kinematics: cartesian

--- a/self-hosted-services/klipper/klipper-deployment.yaml
+++ b/self-hosted-services/klipper/klipper-deployment.yaml
@@ -27,10 +27,10 @@ spec:
         - name: klipper-config
           configMap:
             name: klipper-config
-        - name: ttyacm0
+        - name: host-dev
           hostPath:
-            path: /dev/serial/by-id/usb-Klipper_lpc1768_01D00008E5A448AFEBA3375DC42000F5-if00
-            type: CharDevice
+            path: /dev
+            type: Directory
         - name: socket-dir
           emptyDir: {}
       initContainers:
@@ -76,8 +76,8 @@ spec:
               subPath: comms
             - mountPath: /opt/printer_data/run
               name: socket-dir
-            - mountPath: /dev/ttyACM0
-              name: ttyacm0
+            - mountPath: /dev/host
+              name: host-dev
         - name: moonraker
           # renovate: datasource=docker depname=mkuf/moonraker versioning=semver
           image: mkuf/moonraker:latest


### PR DESCRIPTION
Kubernetes hostPath mounts for specific CharDevices break when the USB device disconnects and reconnects (which Klipper does on FIRMWARE_RESTART). By mounting the host's /dev directory and using the dynamic by-id symlink, Klipper can successfully reconnect to the MCU after a restart.