### PR TITLE
fix frigate detection

### DIFF
--- a/self-hosted-services/frigate/frigate-config.yaml
+++ b/self-hosted-services/frigate/frigate-config.yaml
@@ -90,6 +90,7 @@ detect:
 detectors:
   onnx:
     type: onnx
+    device: tensorrt
 model:
   model_type: yolo-generic
   width: 320


### PR DESCRIPTION
- **Fix Frigate detection: use CUDA instead of broken TensorRT**
- **Disable CudaGraphRunner in Frigate to fix deadlock**
- **Completely bypass CudaGraphRunner**
- **Use spawn to fix ONNX CUDA fork deadlock**
- **Revert experimental ONNX CUDA deadlock patches**
- **Enable tensorrt device in Frigate config**
