### PR TITLE
Calibrate extruder rotation distance

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -69,7 +69,7 @@ data:
     dir_pin: !P0.11
     enable_pin: !P2.12
     microsteps: 16
-    rotation_distance: 33.33
+    rotation_distance: 32.163
     nozzle_diameter: 0.400
     filament_diameter: 1.750
     heater_pin: P2.7


### PR DESCRIPTION
Based on manual extrusion test: requested 100mm, actual was 96.5mm (120 - 23.5). New rotation_distance = 33.33 * (96.5 / 100) = 32.163.