### PR TITLE
Increase bed_mesh probe_count

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -120,7 +120,7 @@ data:
     horizontal_move_z: 5
     mesh_min: 24, 10
     mesh_max: 210, 190
-    probe_count: 5, 5
+    probe_count: 7, 7
     algorithm: bicubic
 
     [display]


### PR DESCRIPTION
Increases the bed mesh probe grid from 5x5 (25 points) to 7x7 (49 points) for higher resolution leveling data.