### PR TITLE
Enable exclude_object module

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -120,7 +120,7 @@ data:
     horizontal_move_z: 5
     mesh_min: 24, 10
     mesh_max: 210, 190
-    probe_count: 5, 5
+    probe_count: 7, 7
     algorithm: bicubic
 
     [display]

--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -140,6 +140,8 @@ data:
 
     [pause_resume]
 
+    [exclude_object]
+
     [display_status]
 
     [gcode_macro PAUSE]


### PR DESCRIPTION
Enables the exclude_object module so Klipper can process EXCLUDE_OBJECT_DEFINE macros injected by modern slicers like Cura. This enables the 'Cancel Object' feature in Mainsail.