### PR TITLE
Relax verify_heater for extruder

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -82,6 +82,12 @@ data:
     pid_Ki: 6.7483
     pid_Kd: 91.6859
 
+    [verify_heater extruder]
+    max_error: 200
+    check_gain_time: 30
+    hysteresis: 10
+    heating_gain: 2
+
     [tmc2208 extruder]
     uart_pin: P1.4
     run_current: 0.650

--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -120,7 +120,7 @@ data:
     horizontal_move_z: 5
     mesh_min: 24, 10
     mesh_max: 210, 190
-    probe_count: 5, 5
+    probe_count: 7, 7
     algorithm: bicubic
 
     [display]

--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -140,6 +140,8 @@ data:
 
     [pause_resume]
 
+    [exclude_object]
+
     [display_status]
 
     [gcode_macro PAUSE]


### PR DESCRIPTION
Relaxes the verify_heater safety checks to prevent false-positive thermal shutdowns when the part cooling fan kicks on at 100% on layer 4 and causes sudden temperature drops.