### PR TITLE
Increase bed_mesh horizontal_move_z

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -123,7 +123,7 @@ data:
 
     [bed_mesh]
     speed: 120
-    horizontal_move_z: 5
+    horizontal_move_z: 10
     mesh_min: 24, 10
     mesh_max: 210, 190
     probe_count: 7, 7


### PR DESCRIPTION
Increases the horizontal_move_z from 5 to 10 to give the BLTouch enough clearance to deploy the pin without triggering early due to physical proximity to the bed.