### PR TITLE
Update Klipper for 0.6mm nozzle

### DIFF
--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -70,7 +70,7 @@ data:
     enable_pin: !P2.12
     microsteps: 16
     rotation_distance: 32.163
-    nozzle_diameter: 0.400
+    nozzle_diameter: 0.600
     filament_diameter: 1.750
     heater_pin: P2.7
     sensor_type: EPCOS 100K B57560G104F

--- a/self-hosted-services/klipper/klipper-configmap.yaml
+++ b/self-hosted-services/klipper/klipper-configmap.yaml
@@ -123,7 +123,7 @@ data:
 
     [bed_mesh]
     speed: 120
-    horizontal_move_z: 5
+    horizontal_move_z: 10
     mesh_min: 24, 10
     mesh_max: 210, 190
     probe_count: 7, 7


### PR DESCRIPTION
Updates the nozzle_diameter in Klipper to 0.600. This prevents the 'Move exceeds maximum extrusion cross section' safety error when slicing wider, thicker lines.